### PR TITLE
Restrict guzzle to 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     }],
     "require": {
         "php": ">=5.4.0",
-        "socialiteproviders/manager": "0.1.*"
+        "socialiteproviders/manager": "0.1.*",
+        "guzzlehttp/guzzle": "^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The 6.0 release of Guzzle breaks the package in a couple of places. I think this should be a patch version to this package. I'll be shortly adding a second PR that fixes a couple of the 6.0 issues I ran into.
