### PR TITLE
Support Guzzle 6.0

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -41,12 +41,12 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getUserByToken($token)
     {
-        $response = $this->getHttpClient()->get(
+        $response = json_decode($this->getHttpClient()->get(
             'https://api.instagram.com/v1/users/self?access_token='.$token, [
             'headers' => [
                 'Accept' => 'application/json',
             ],
-        ])->json();
+        ])->getBody()->getContents(), true);
 
         return $response['data'];
     }
@@ -69,7 +69,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     public function getAccessToken($code)
     {
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
-            'body' => $this->getTokenFields($code),
+            'body' => http_build_query($this->getTokenFields($code)),
         ]);
 
         return $this->parseAccessToken($response->getBody());


### PR DESCRIPTION
This fixes the source of a couple exceptions I ran into when trying to use with Guzzle 6.0. 
- It no longer allows arrays to be passed into the `body` option
- It drops support for `->json()`
