### PR TITLE
Migrate Instagram API  (deprecation of the Instagram Basic Display API)

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -41,7 +41,7 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
-    protected $scopes = ['instagram_basic'];
+    protected $scopes = ['instagram_business_basic'];
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
### Summary

This PR updates the Instagram provider to reflect recent changes from Meta, deprecating the Instagram Basic Display API and the `user_profile` scope.

### Changes
- Replaces the `user_profile` scope with `instagram_business_basic`
- Adds support for additional fields now available via the Instagram API

### Why

> As of **September 4, 2024**, Meta has announced the deprecation of the Instagram Basic Display API. All requests to this API will fail starting **December 4, 2024**.

See official notice: [On September 4, 2024, we announced the deprecation of the Instagram Basic Display API.](https://developers.facebook.com/docs/instagram-platform/#:~:text=On%20September%204%2C%202024%2C%20we%20announced%20the%20deprecation%20of%20the%20Instagram%20Basic%20Display%20API.)
![image](https://github.com/user-attachments/assets/d9e7fa91-83f9-4f76-a282-beb18d35fe8e)

