### PR TITLE
fix: correct scope separator and update auth URL for Instagram provider

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -21,13 +21,21 @@ class Provider extends AbstractProvider
 
     protected $scopes = ['instagram_business_basic'];
 
+    protected function buildAuthUrlFromBase($url, $state)
+    {
+        $query = http_build_query(
+            $this->getCodeFields($state),
+            '',
+            '&',
+            $this->encodingType
+        );
+
+        return $url . '?' . urldecode($query);
+    }
+
     protected function getAuthUrl($state): string
     {
-        return str_replace(
-            '&amp;',
-            '&',
-            $this->buildAuthUrlFromBase('https://www.instagram.com/oauth/authorize', $state)
-        );
+        return $this->buildAuthUrlFromBase('https://www.instagram.com/oauth/authorize', $state);
     }
 
     protected function getTokenUrl(): string

--- a/Provider.php
+++ b/Provider.php
@@ -23,7 +23,11 @@ class Provider extends AbstractProvider
 
     protected function getAuthUrl($state): string
     {
-        return $this->buildAuthUrlFromBase('https://www.instagram.com/oauth/authorize', $state);
+        return str_replace(
+            '&amp;',
+            '&',
+            $this->buildAuthUrlFromBase('https://www.instagram.com/oauth/authorize', $state)
+        );
     }
 
     protected function getTokenUrl(): string

--- a/Provider.php
+++ b/Provider.php
@@ -10,7 +10,7 @@ class Provider extends AbstractProvider
 {
     public const IDENTIFIER = 'INSTAGRAM';
 
-    protected $scopeSeparator = ' ';
+    protected $scopeSeparator = ',';
 
     /**
      * The user fields being requested.
@@ -23,7 +23,7 @@ class Provider extends AbstractProvider
 
     protected function getAuthUrl($state): string
     {
-        return $this->buildAuthUrlFromBase('https://api.instagram.com/oauth/authorize', $state);
+        return $this->buildAuthUrlFromBase('https://www.instagram.com/oauth/authorize', $state);
     }
 
     protected function getTokenUrl(): string


### PR DESCRIPTION
This pull request updates the Instagram OAuth provider implementation to improve compatibility with Instagram's authentication flow. The most important changes are related to the OAuth URL and scope separator.

Authentication flow updates:

* Changed the authorization URL in the `getAuthUrl` method from `https://api.instagram.com/oauth/authorize` to `https://www.instagram.com/oauth/authorize`, ensuring the provider uses the correct endpoint for Instagram authentication.

OAuth configuration:

* Updated the `scopeSeparator` property from a space (`' '`) to a comma (`','`), matching Instagram's expected format for scopes in OAuth requests.